### PR TITLE
T03 — Componentes UI base (Modal, ConfirmModal, Toast, ToastContext)

### DIFF
--- a/app/src/components/ui/ConfirmModal.tsx
+++ b/app/src/components/ui/ConfirmModal.tsx
@@ -1,0 +1,46 @@
+import Modal from '@/components/ui/Modal'
+
+type ConfirmModalProps = {
+  isOpen: boolean
+  title: string
+  message: string
+  confirmLabel: string
+  cancelLabel?: string
+  variant: 'primary' | 'destructive'
+  onConfirm: () => void
+  onCancel: () => void
+}
+
+const confirmStyles: Record<string, string> = {
+  primary: 'px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-md',
+  destructive: 'px-4 py-2 bg-red-600 hover:bg-red-700 text-white rounded-md',
+}
+
+export default function ConfirmModal({
+  isOpen,
+  title,
+  message,
+  confirmLabel,
+  cancelLabel = 'Cancelar',
+  variant,
+  onConfirm,
+  onCancel,
+}: ConfirmModalProps) {
+  return (
+    <Modal isOpen={isOpen} onClose={onCancel} maxWidth="sm">
+      <h2 className="text-lg font-semibold">{title}</h2>
+      <p className="text-gray-600 mt-2">{message}</p>
+      <div className="flex justify-end gap-3 mt-6">
+        <button
+          onClick={onCancel}
+          className="px-4 py-2 text-gray-700 bg-gray-100 hover:bg-gray-200 rounded-md"
+        >
+          {cancelLabel}
+        </button>
+        <button onClick={onConfirm} className={confirmStyles[variant]}>
+          {confirmLabel}
+        </button>
+      </div>
+    </Modal>
+  )
+}

--- a/app/src/components/ui/Modal.tsx
+++ b/app/src/components/ui/Modal.tsx
@@ -1,0 +1,57 @@
+import { useEffect } from 'react'
+import type { ReactNode } from 'react'
+import { createPortal } from 'react-dom'
+
+type ModalProps = {
+  isOpen: boolean
+  onClose: () => void
+  maxWidth?: 'sm' | 'md' | 'lg'
+  children: ReactNode
+}
+
+const maxWidthClasses: Record<string, string> = {
+  sm: 'max-w-[384px]',
+  md: 'max-w-[448px]',
+  lg: 'max-w-[512px]',
+}
+
+export default function Modal({ isOpen, onClose, maxWidth = 'md', children }: ModalProps) {
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        onClose()
+      }
+    }
+    document.addEventListener('keydown', handleKeyDown)
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown)
+    }
+  }, [onClose])
+
+  if (!isOpen) return null
+
+  return createPortal(
+    <div
+      className="fixed inset-0 bg-black/50 flex items-center justify-center z-50"
+      onClick={(event) => {
+        if (event.target === event.currentTarget) {
+          onClose()
+        }
+      }}
+    >
+      <div
+        className={`bg-white rounded-lg shadow-xl ${maxWidthClasses[maxWidth]} w-full mx-4 p-6 relative`}
+      >
+        <button
+          onClick={onClose}
+          className="absolute top-3 right-3 text-gray-400 hover:text-gray-600"
+          aria-label="Close"
+        >
+          ✕
+        </button>
+        {children}
+      </div>
+    </div>,
+    document.body,
+  )
+}

--- a/app/src/components/ui/Toast.tsx
+++ b/app/src/components/ui/Toast.tsx
@@ -1,0 +1,43 @@
+import { useEffect, useRef } from 'react'
+
+type ToastProps = {
+  message: string
+  type: 'success' | 'error'
+  onClose: () => void
+}
+
+const toastStyles: Record<string, string> = {
+  success: 'bg-green-50 text-green-800 border border-green-200',
+  error: 'bg-red-50 text-red-800 border border-red-200',
+}
+
+export default function Toast({ message, type, onClose }: ToastProps) {
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => {
+    const duration = type === 'success' ? 3000 : 5000
+    timerRef.current = setTimeout(() => {
+      onClose()
+    }, duration)
+    return () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current)
+      }
+    }
+  }, [type, onClose])
+
+  return (
+    <div
+      className={`flex items-center justify-between gap-2 px-4 py-3 rounded-lg shadow-lg min-w-[300px] ${toastStyles[type]}`}
+    >
+      <span>{message}</span>
+      <button
+        onClick={onClose}
+        className="text-current opacity-70 hover:opacity-100"
+        aria-label="Close"
+      >
+        ✕
+      </button>
+    </div>
+  )
+}

--- a/app/src/context/ToastContext.tsx
+++ b/app/src/context/ToastContext.tsx
@@ -1,0 +1,37 @@
+/* eslint-disable react-refresh/only-export-components */
+import { createContext, useState } from 'react'
+import type { ReactNode } from 'react'
+import Toast from '@/components/ui/Toast'
+
+type ToastData = { message: string; type: 'success' | 'error' }
+
+export type ToastContextValue = {
+  toast: ToastData | null
+  showToast: (message: string, type: 'success' | 'error') => void
+  dismissToast: () => void
+}
+
+export const ToastContext = createContext<ToastContextValue | null>(null)
+
+export function ToastProvider({ children }: { children: ReactNode }) {
+  const [toast, setToast] = useState<ToastData | null>(null)
+
+  const showToast = (message: string, type: 'success' | 'error') => {
+    setToast({ message, type })
+  }
+
+  const dismissToast = () => {
+    setToast(null)
+  }
+
+  return (
+    <ToastContext.Provider value={{ toast, showToast, dismissToast }}>
+      {children}
+      {toast !== null && (
+        <div className="fixed top-4 right-4 z-50">
+          <Toast message={toast.message} type={toast.type} onClose={dismissToast} />
+        </div>
+      )}
+    </ToastContext.Provider>
+  )
+}

--- a/app/src/hooks/useToast.ts
+++ b/app/src/hooks/useToast.ts
@@ -1,0 +1,8 @@
+import { useContext } from 'react'
+import { ToastContext } from '@/context/ToastContext'
+
+export function useToast() {
+  const context = useContext(ToastContext)
+  if (!context) throw new Error('useToast must be used within ToastProvider')
+  return context
+}


### PR DESCRIPTION
## Resumen

Crea los componentes UI reutilizables y el sistema de notificaciones que serán
consumidos por el resto de la aplicación.

## Cambios incluidos

### Componentes UI
- **Modal.tsx** — Modal genérico con `createPortal`, cierre por Escape y clic fuera del panel, prop `maxWidth` (sm/md/lg)
- **ConfirmModal.tsx** — Diálogo de confirmación que compone Modal, con variantes `primary` y `destructive`
- **Toast.tsx** — Notificación con auto-dismiss (3s success, 5s error), cierre manual, estilos por tipo

### Contexto y hooks
- **ToastContext.tsx** — Provider con estado de toast, `showToast` y `dismissToast`, renderiza Toast en posición fixed
- **useToast.ts** — Hook facade con validación de provider

## Validaciones

- [x] `npm run build` compila sin errores
- [x] `npm run check` (tsc + eslint + prettier) pasa limpio
- [x] No se modifica App.tsx

Closes #5