### PR TITLE
T04 — Estado global y persistencia en localStorage

### DIFF
--- a/app/src/context/ApiKeyContext.tsx
+++ b/app/src/context/ApiKeyContext.tsx
@@ -1,0 +1,24 @@
+/* eslint-disable react-refresh/only-export-components */
+import { createContext } from 'react'
+import type { ReactNode } from 'react'
+import { useLocalStorage } from '@/hooks/useLocalStorage'
+
+type ApiKeyContextValue = {
+  apiKey: string
+  setApiKey: (key: string) => void
+  clearApiKey: () => void
+  hasApiKey: boolean
+}
+
+export const ApiKeyContext = createContext<ApiKeyContextValue | null>(null)
+
+export function ApiKeyProvider({ children }: { children: ReactNode }) {
+  const [apiKey, setApiKey] = useLocalStorage<string>('gemini_api_key', '')
+
+  const clearApiKey = () => setApiKey('')
+  const hasApiKey = apiKey.length > 0
+
+  return (
+    <ApiKeyContext value={{ apiKey, setApiKey, clearApiKey, hasApiKey }}>{children}</ApiKeyContext>
+  )
+}

--- a/app/src/context/TaskContext.tsx
+++ b/app/src/context/TaskContext.tsx
@@ -1,0 +1,96 @@
+/* eslint-disable react-refresh/only-export-components */
+import { createContext, useEffect, useReducer } from 'react'
+import type { ReactNode } from 'react'
+import type { Task, TaskAction } from '@/types/task'
+import { createTask } from '@/utils/task'
+import { calculateIceScore } from '@/utils/ice'
+import { useLocalStorage } from '@/hooks/useLocalStorage'
+
+type TaskState = {
+  tasks: Task[]
+}
+
+type TaskContextValue = {
+  tasks: Task[]
+  dispatch: React.Dispatch<TaskAction>
+}
+
+export const TaskContext = createContext<TaskContextValue | null>(null)
+
+function taskReducer(state: TaskState, action: TaskAction): TaskState {
+  switch (action.type) {
+    case 'ADD_TASK': {
+      const newTask = createTask(action.payload.title, action.payload.description)
+      return { tasks: [...state.tasks, newTask] }
+    }
+    case 'UPDATE_TASK': {
+      return {
+        tasks: state.tasks.map((task) =>
+          task.id === action.payload.id
+            ? { ...task, ...action.payload.changes, updatedAt: new Date().toISOString() }
+            : task,
+        ),
+      }
+    }
+    case 'UPDATE_ICE_MANUAL': {
+      return {
+        tasks: state.tasks.map((task) => {
+          if (task.id !== action.payload.id) return task
+          const impact = action.payload.impact ?? task.ice.impact
+          const confidence = action.payload.confidence ?? task.ice.confidence
+          const ease = action.payload.ease ?? task.ice.ease
+          return {
+            ...task,
+            ice: {
+              impact,
+              confidence,
+              ease,
+              score: calculateIceScore(impact, confidence, ease),
+              source: 'manual' as const,
+              rationale: undefined,
+            },
+            updatedAt: new Date().toISOString(),
+          }
+        }),
+      }
+    }
+    case 'UPDATE_ICE_AI': {
+      const { id, impact, confidence, ease, rationale } = action.payload
+      return {
+        tasks: state.tasks.map((task) =>
+          task.id === id
+            ? {
+                ...task,
+                ice: {
+                  impact,
+                  confidence,
+                  ease,
+                  score: calculateIceScore(impact, confidence, ease),
+                  rationale,
+                  source: 'ai' as const,
+                },
+                updatedAt: new Date().toISOString(),
+              }
+            : task,
+        ),
+      }
+    }
+    case 'DELETE_TASK': {
+      return { tasks: state.tasks.filter((task) => task.id !== action.payload.id) }
+    }
+    case 'SET_TASKS': {
+      return { tasks: action.payload.tasks }
+    }
+  }
+}
+
+export function TaskProvider({ children }: { children: ReactNode }) {
+  const [storedTasks, setStoredTasks] = useLocalStorage<Task[]>('tasks', [])
+  const [state, dispatch] = useReducer(taskReducer, { tasks: storedTasks })
+
+  useEffect(() => {
+    setStoredTasks(state.tasks)
+  }, [state.tasks, setStoredTasks])
+
+  return <TaskContext value={{ tasks: state.tasks, dispatch }}>{children}</TaskContext>
+}

--- a/app/src/hooks/useApiKey.ts
+++ b/app/src/hooks/useApiKey.ts
@@ -1,0 +1,8 @@
+import { useContext } from 'react'
+import { ApiKeyContext } from '@/context/ApiKeyContext'
+
+export function useApiKey() {
+  const context = useContext(ApiKeyContext)
+  if (!context) throw new Error('useApiKey must be used within ApiKeyProvider')
+  return context
+}

--- a/app/src/hooks/useLocalStorage.ts
+++ b/app/src/hooks/useLocalStorage.ts
@@ -1,0 +1,37 @@
+import { useCallback, useEffect, useState } from 'react'
+
+export function useLocalStorage<T>(key: string, initialValue: T): [T, (value: T) => void] {
+  const [storedValue, setStoredValue] = useState<T>(() => {
+    try {
+      const item = localStorage.getItem(key)
+      return item ? (JSON.parse(item) as T) : initialValue
+    } catch {
+      return initialValue
+    }
+  })
+
+  const setValue = useCallback(
+    (value: T) => {
+      setStoredValue(value)
+      localStorage.setItem(key, JSON.stringify(value))
+    },
+    [key],
+  )
+
+  useEffect(() => {
+    const handleStorage = (event: StorageEvent) => {
+      if (event.key === key) {
+        try {
+          const newValue = event.newValue ? (JSON.parse(event.newValue) as T) : initialValue
+          setStoredValue(newValue)
+        } catch {
+          setStoredValue(initialValue)
+        }
+      }
+    }
+    window.addEventListener('storage', handleStorage)
+    return () => window.removeEventListener('storage', handleStorage)
+  }, [key, initialValue])
+
+  return [storedValue, setValue]
+}

--- a/app/src/hooks/useTasks.ts
+++ b/app/src/hooks/useTasks.ts
@@ -1,0 +1,25 @@
+import { useContext } from 'react'
+import type { Task } from '@/types/task'
+import { TaskContext } from '@/context/TaskContext'
+
+export function useTasks() {
+  const context = useContext(TaskContext)
+  if (!context) throw new Error('useTasks must be used within TaskProvider')
+  const { tasks, dispatch } = context
+
+  return {
+    tasks,
+    addTask: (title: string, description?: string) =>
+      dispatch({ type: 'ADD_TASK', payload: { title, description } }),
+    updateTask: (id: string, changes: Partial<Pick<Task, 'title' | 'description' | 'status'>>) =>
+      dispatch({ type: 'UPDATE_TASK', payload: { id, changes } }),
+    updateIceManual: (id: string, ice: { impact?: number; confidence?: number; ease?: number }) =>
+      dispatch({ type: 'UPDATE_ICE_MANUAL', payload: { id, ...ice } }),
+    updateIceAi: (
+      id: string,
+      ice: { impact: number; confidence: number; ease: number; rationale: string },
+    ) => dispatch({ type: 'UPDATE_ICE_AI', payload: { id, ...ice } }),
+    deleteTask: (id: string) => dispatch({ type: 'DELETE_TASK', payload: { id } }),
+    setTasks: (tasks: Task[]) => dispatch({ type: 'SET_TASKS', payload: { tasks } }),
+  }
+}

--- a/app/src/services/persistence.localStorage.ts
+++ b/app/src/services/persistence.localStorage.ts
@@ -1,0 +1,39 @@
+import type { PersistenceAdapter } from './persistence'
+import type { Task } from '@/types/task'
+
+const TASKS_KEY = 'tasks'
+const API_KEY = 'gemini_api_key'
+
+function safeParse<T>(value: string | null, fallback: T): T {
+  if (!value) return fallback
+  try {
+    return JSON.parse(value) as T
+  } catch {
+    return fallback
+  }
+}
+
+export const localStorageAdapter: PersistenceAdapter = {
+  async loadTasks(): Promise<Task[]> {
+    return safeParse<Task[]>(localStorage.getItem(TASKS_KEY), [])
+  },
+  async saveTasks(tasks: Task[]): Promise<void> {
+    localStorage.setItem(TASKS_KEY, JSON.stringify(tasks))
+  },
+  async loadApiKey(): Promise<string> {
+    return safeParse<string>(localStorage.getItem(API_KEY), '')
+  },
+  async saveApiKey(key: string): Promise<void> {
+    localStorage.setItem(API_KEY, JSON.stringify(key))
+  },
+  async clearApiKey(): Promise<void> {
+    localStorage.removeItem(API_KEY)
+  },
+  subscribe(handler) {
+    const onStorage = (event: StorageEvent) => {
+      if (event.key === TASKS_KEY || event.key === API_KEY) handler()
+    }
+    window.addEventListener('storage', onStorage)
+    return () => window.removeEventListener('storage', onStorage)
+  },
+}

--- a/app/src/services/persistence.ts
+++ b/app/src/services/persistence.ts
@@ -1,0 +1,21 @@
+import type { Task } from '@/types/task'
+
+export type PersistenceAdapter = {
+  loadTasks: () => Promise<Task[]>
+  saveTasks: (tasks: Task[]) => Promise<void>
+  loadApiKey: () => Promise<string>
+  saveApiKey: (key: string) => Promise<void>
+  clearApiKey: () => Promise<void>
+  subscribe?: (handler: () => void) => () => void
+}
+
+let adapter: PersistenceAdapter
+
+export function setPersistenceAdapter(next: PersistenceAdapter) {
+  adapter = next
+}
+
+export function getPersistenceAdapter(): PersistenceAdapter {
+  if (!adapter) throw new Error('Persistence adapter not initialized')
+  return adapter
+}


### PR DESCRIPTION
## Resumen

Implementa el estado global (tareas y API key) con useReducer + Context,
la capa de persistencia con inversión de dependencias, y los hooks facade.

## Cambios incluidos

### Persistencia
- **persistence.ts** — Contrato `PersistenceAdapter` con get/set para inyección de dependencias
- **persistence.localStorage.ts** — Implementación localStorage del adapter con `safeParse` y sync cross-tab

### Hooks
- **useLocalStorage.ts** — Hook genérico con lazy init, escritura y sincronización entre pestañas
- **useTasks.ts** — Facade que expone addTask, updateTask, updateIceManual, updateIceAi, deleteTask, setTasks
- **useApiKey.ts** — Facade que expone apiKey, setApiKey, clearApiKey, hasApiKey

### Contextos
- **TaskContext.tsx** — Reducer completo con 6 acciones (ADD, UPDATE, UPDATE_ICE_MANUAL, UPDATE_ICE_AI, DELETE, SET_TASKS) + persistencia via useLocalStorage
- **ApiKeyContext.tsx** — Estado de API key con valor derivado `hasApiKey`

## Nota

El paso 4.5 (montar providers en App.tsx + inicializar adapter en main.tsx) se
hará en un commit de integración tras mergear T03, ya que depende de ToastProvider.

## Validaciones

- [x] `npm run build` compila sin errores
- [x] `npm run check` (tsc + eslint + prettier) pasa limpio
- [x] No se modifica App.tsx ni main.tsx

Closes #6