### PR TITLE
Integración T03+T04 — Montar providers y persistence adapter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist
 .env
 .env.*
 !.env.example
+.worktrees/

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1,7 +1,37 @@
+import { ToastProvider } from '@/context/ToastContext'
+import { ApiKeyProvider } from '@/context/ApiKeyContext'
+import { TaskProvider } from '@/context/TaskContext'
+import { useApiKey } from '@/hooks/useApiKey'
+
 function App() {
+  return (
+    <ToastProvider>
+      <ApiKeyProvider>
+        <TaskProvider>
+          <AppContent />
+        </TaskProvider>
+      </ApiKeyProvider>
+    </ToastProvider>
+  )
+}
+
+function AppContent() {
+  const { hasApiKey } = useApiKey()
+  return hasApiKey ? <MainView /> : <ApiKeySetup />
+}
+
+function MainView() {
   return (
     <div className="min-h-screen bg-gray-100 flex items-center justify-center">
       <h1 className="text-3xl font-bold text-blue-600">Gestor de Tareas ICE</h1>
+    </div>
+  )
+}
+
+function ApiKeySetup() {
+  return (
+    <div className="min-h-screen bg-gray-100 flex items-center justify-center">
+      <h1 className="text-3xl font-bold text-gray-600">Configurar API Key</h1>
     </div>
   )
 }

--- a/app/src/main.tsx
+++ b/app/src/main.tsx
@@ -1,7 +1,11 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import { setPersistenceAdapter } from '@/services/persistence'
+import { localStorageAdapter } from '@/services/persistence.localStorage'
 import './index.css'
 import App from './App.tsx'
+
+setPersistenceAdapter(localStorageAdapter)
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>


### PR DESCRIPTION
## Resumen

Completa el paso 4.5 de la implementación: monta los providers en App.tsx en el
orden definido por la arquitectura e inicializa el persistence adapter en main.tsx.

## Cambios incluidos

- **main.tsx**: inicializa `localStorageAdapter` via `setPersistenceAdapter()` antes del render
- **App.tsx**: monta `ToastProvider > ApiKeyProvider > TaskProvider`, añade `AppContent` con routing por `hasApiKey`, placeholders para `MainView` y `ApiKeySetup`
- **.gitignore**: añade `.worktrees/`

## Validaciones

- [x] `npm run build` compila sin errores (39 módulos)
- [x] `npm run check` (tsc + eslint + prettier) pasa limpio